### PR TITLE
Fixed GetGroundAltitude

### DIFF
--- a/Plugin/Trajectory.cs
+++ b/Plugin/Trajectory.cs
@@ -124,17 +124,17 @@ namespace Trajectories
         // relativePosition is in world frame, but relative to the body
         private double GetGroundAltitude(CelestialBody body, Vector3 relativePosition)
         {
-			if (body.pqsController == null)
-				return 0;
+            if (body.pqsController == null)
+                return 0;
 
-			double lat = body.GetLatitude(relativePosition + body.position) / 180.0 * Math.PI;
-			double lon = body.GetLongitude(relativePosition + body.position) / 180.0 * Math.PI;
-			Vector3d rad = new Vector3d(Math.Cos(lat) * Math.Cos(lon), Math.Sin(lat), Math.Cos(lat) * Math.Sin(lon));
-			double elevation = body.pqsController.GetSurfaceHeight(rad) - body.Radius;
-			if (body.ocean)
-				elevation = Math.Max(elevation, 0.0);
+            double lat = body.GetLatitude(relativePosition + body.position) / 180.0 * Math.PI;
+            double lon = body.GetLongitude(relativePosition + body.position) / 180.0 * Math.PI;
+            Vector3d rad = new Vector3d(Math.Cos(lat) * Math.Cos(lon), Math.Sin(lat), Math.Cos(lat) * Math.Sin(lon));
+            double elevation = body.pqsController.GetSurfaceHeight(rad) - body.Radius;
+            if (body.ocean)
+                elevation = Math.Max(elevation, 0.0);
 
-			return elevation;
+            return elevation;
         }
 
         private VesselState AddPatch(VesselState startingState)


### PR DESCRIPTION
Calculation was incorrect for terrain-less bodies (radius was added)
Calculation was incorrect for ocean-less bodies (negative elevations were zeroed-out)
