### PR TITLE
API space orbit correction

### DIFF
--- a/Plugin/API.cs
+++ b/Plugin/API.cs
@@ -31,11 +31,18 @@ namespace Trajectories
         {
             foreach (var patch in Trajectory.fetch.patches)
             {
+                if (patch.startingState.stockPatch != null)
+                    continue;
+		    
+		if (patch.isAtmospheric)
+                    continue;
+
                 if (patch.spaceOrbit != null)
-                    return patch.spaceOrbit;
+                	return patch.spaceOrbit;
             }
             return null;	
 	}
+	    
         public static Vector3 getImpactVelocity()
         {
             foreach (var patch in Trajectory.fetch.patches)

--- a/Plugin/API.cs
+++ b/Plugin/API.cs
@@ -32,18 +32,22 @@ namespace Trajectories
             foreach (var patch in Trajectory.fetch.patches)
             {
                 if (patch.startingState.stockPatch != null)
+		{
                     continue;
-		    
+		} 
 		if (patch.isAtmospheric)
+		{
                     continue;
-
+		}
                 if (patch.spaceOrbit != null)
+		{
                 	return patch.spaceOrbit;
+		}
             }
             return null;	
 	}
 	    
-        public static Vector3 getImpactVelocity()
+        public static Vector3? getImpactVelocity()
         {
             foreach (var patch in Trajectory.fetch.patches)
             {


### PR DESCRIPTION
I basically skimmed the bits from the map overlay code. for the first if/continue I took out the settings.fetch.displaycompletetrajectory because I figured it doesnt matter for KOS or anyone else using the API really if the trajectory is displayed or not. I also removed settings.fetch.bodyfixedmode as I think a space orbit should be available regardless of what display mode you are in. 
It goes through all the patches until it finds one that is not in atmo, after atmo, and returns it.
Although, I am not sure if it stops then, or if it will try to continue returning patch.spaceOrbit over and over if there are multiple passes through the atmosphere. I think it does return as soon as it finds one though. 
I am also assuming that the very next patch after patch.startingState.stockPatch goes null, patch.isAtmospheric becomes true. If not I may need the  
if (patch.isAtmospheric && patch.atmosphericTrajectory.Length < 2)
                    continue;
part also.