### PR TITLE
Ground Trace from orbit

### DIFF
--- a/Plugin/FlightOverlay.cs
+++ b/Plugin/FlightOverlay.cs
@@ -1,5 +1,4 @@
 ﻿using UnityEngine;
-using Vectrosity;
 
 namespace Trajectories
 {

--- a/Plugin/MapGUI.cs
+++ b/Plugin/MapGUI.cs
@@ -151,6 +151,12 @@ namespace Trajectories
 
             GUILayout.EndHorizontal();
 
+            GUILayout.BeginHorizontal();
+            
+            Settings.fetch.GroundTraceMode = GUILayout.Toggle(Settings.fetch.GroundTraceMode, "Ground Trace mode");
+            
+            GUILayout.EndHorizontal();
+
             GUILayout.Label("Max G-force: " + (traj.MaxAccel / 9.81).ToString("0.00"));
             if (lastPatch != null && lastPatch.impactPosition.HasValue)
             {

--- a/Plugin/MapGUI.cs
+++ b/Plugin/MapGUI.cs
@@ -152,9 +152,12 @@ namespace Trajectories
             GUILayout.EndHorizontal();
 
             GUILayout.BeginHorizontal();
-            
-            Settings.fetch.GroundTraceMode = GUILayout.Toggle(Settings.fetch.GroundTraceMode, "Ground Trace mode");
-            
+
+            if (Settings.fetch.BodyFixedMode)
+            {
+                Settings.fetch.GroundTraceMode = GUILayout.Toggle(Settings.fetch.GroundTraceMode, "Ground Trace mode");
+            }
+
             GUILayout.EndHorizontal();
 
             GUILayout.Label("Max G-force: " + (traj.MaxAccel / 9.81).ToString("0.00"));

--- a/Plugin/MapOverlay.cs
+++ b/Plugin/MapOverlay.cs
@@ -182,6 +182,10 @@ namespace Trajectories
                     if (Settings.fetch.GroundTraceMode)
                     {
                         initMeshFromOrbit(patch.startingState.referenceBody.position, groundTraceMesh, patch.spaceOrbit, patch.startingState.time, patch.endTime - patch.startingState.time, XKCDColors.Orange, true);
+
+                    } else
+                    {
+                        
                     }
                 }
 

--- a/Plugin/MapOverlay.cs
+++ b/Plugin/MapOverlay.cs
@@ -286,12 +286,7 @@ namespace Trajectories
 
                 if (Settings.fetch.GroundTraceMode)
                 {
-                    Vector3 curMeshPosWorld = curMeshPos + bodyPosition;
-                    CelestialBody body = orbit.referenceBody;
-                    var latitude = body.GetLatitude(curMeshPosWorld);
-                    var longitude = body.GetLongitude(curMeshPosWorld);
-                    var NormalV = body.GetSurfaceNVector(latitude, longitude);
-                    curMeshPos -= (NormalV * (float)body.GetAltitude(curMeshPos + bodyPosition));
+                    curMeshPos = Trajectory.projectToSurface(orbit.referenceBody, curMeshPos, time);
                 }
 
                 curMeshPos += bodyPosition;

--- a/Plugin/MapOverlay.cs
+++ b/Plugin/MapOverlay.cs
@@ -33,8 +33,6 @@ namespace Trajectories
 
         private float lineWidth = 3.0f;
 
-        private GameObject groundTraceObj;
-
         private void DetachCamera()
         {
             if (attachedCamera == null)
@@ -82,8 +80,6 @@ namespace Trajectories
 
         private void setDisplayEnabled(bool enabled)
         {
-            groundTraceObj.GetComponent<MeshRenderer>().enabled = Settings.fetch.GroundTraceMode;
-
             enabled = enabled && Settings.fetch.DisplayTrajectories;
 
             if (displayEnabled == enabled)
@@ -138,7 +134,7 @@ namespace Trajectories
                 GameObject.Destroy(mesh);
             }
         }
-        
+
         private void refreshMesh()
         {
             foreach (var mesh in meshes)
@@ -173,16 +169,12 @@ namespace Trajectories
                 {
                     initMeshFromOrbit(patch.startingState.referenceBody.position, mesh, patch.spaceOrbit, patch.startingState.time, patch.endTime - patch.startingState.time, Color.white);
 
-                    groundTraceObj = GetMesh(patch.startingState.referenceBody, lineMaterial);
+                    var groundTraceObj = GetMesh(patch.startingState.referenceBody, lineMaterial);
                     var groundTraceMesh = groundTraceObj.GetComponent<MeshFilter>().mesh;
 
                     if (Settings.fetch.GroundTraceMode)
                     {
                         initMeshFromOrbit(patch.startingState.referenceBody.position, groundTraceMesh, patch.spaceOrbit, patch.startingState.time, patch.endTime - patch.startingState.time, XKCDColors.Orange, true);
-
-                    } else
-                    {
-                        
                     }
                 }
 

--- a/Plugin/MapOverlay.cs
+++ b/Plugin/MapOverlay.cs
@@ -82,12 +82,9 @@ namespace Trajectories
 
         private void setDisplayEnabled(bool enabled)
         {
-            enabled = enabled && Settings.fetch.DisplayTrajectories;
+            groundTraceObj.GetComponent<MeshRenderer>().enabled = Settings.fetch.GroundTraceMode;
 
-            if (groundTraceObj)
-            {
-                groundTraceObj.GetComponent<MeshRenderer>().enabled = enabled && Settings.fetch.GroundTraceMode;
-            }
+            enabled = enabled && Settings.fetch.DisplayTrajectories;
 
             if (displayEnabled == enabled)
                 return;

--- a/Plugin/MapOverlay.cs
+++ b/Plugin/MapOverlay.cs
@@ -156,19 +156,16 @@ namespace Trajectories
                 lineMaterial = MapView.fetch.orbitLinesMaterial;
             }
 
-            if (Settings.fetch.GroundTraceMode)
+            foreach (var patch in Trajectory.fetch.patches)
             {
-                foreach (var patch in Trajectory.fetch.patches)
+                if (Settings.fetch.GroundTraceMode)
                 {
                     groundTraceObj = GetMesh(patch.startingState.referenceBody, lineMaterial);
                     var groundTraceMesh = groundTraceObj.GetComponent<MeshFilter>().mesh;
 
                     initMeshFromOrbit(patch.startingState.referenceBody.position, groundTraceMesh, patch.spaceOrbit, patch.startingState.time, patch.endTime - patch.startingState.time, XKCDColors.Orange, true);
                 }
-            }
 
-            foreach (var patch in Trajectory.fetch.patches)
-            {
                 if (patch.startingState.stockPatch != null && !Settings.fetch.BodyFixedMode && !Settings.fetch.DisplayCompleteTrajectory)
                     continue;
 

--- a/Plugin/MapOverlay.cs
+++ b/Plugin/MapOverlay.cs
@@ -283,6 +283,17 @@ namespace Trajectories
                 if (Settings.fetch.BodyFixedMode) {
                     curMeshPos = Trajectory.calculateRotatedPosition(orbit.referenceBody, curMeshPos, time);
                 }
+
+                if (Settings.fetch.GroundTraceMode)
+                {
+                    Vector3 curMeshPosWorld = curMeshPos + bodyPosition;
+                    CelestialBody body = orbit.referenceBody;
+                    var latitude = body.GetLatitude(curMeshPosWorld);
+                    var longitude = body.GetLongitude(curMeshPosWorld);
+                    var NormalV = body.GetSurfaceNVector(latitude, longitude);
+                    curMeshPos -= (NormalV * (float)body.GetAltitude(curMeshPos + bodyPosition));
+                }
+
                 curMeshPos += bodyPosition;
 
                 // add a segment to the trajectory mesh

--- a/Plugin/MapOverlay.cs
+++ b/Plugin/MapOverlay.cs
@@ -159,7 +159,7 @@ namespace Trajectories
 
             foreach (var patch in Trajectory.fetch.patches)
             {
-                if (patch.startingState.stockPatch != null && !Settings.fetch.BodyFixedMode && !Settings.fetch.DisplayCompleteTrajectory)
+                if (patch.startingState.stockPatch != null && !Settings.fetch.GroundTraceMode && !Settings.fetch.BodyFixedMode && !Settings.fetch.DisplayCompleteTrajectory)
                     continue;
 
                 if (patch.isAtmospheric && patch.atmosphericTrajectory.Length < 2)

--- a/Plugin/MapOverlay.cs
+++ b/Plugin/MapOverlay.cs
@@ -33,6 +33,8 @@ namespace Trajectories
 
         private float lineWidth = 3.0f;
 
+        private GameObject groundTraceObj;
+
         private void DetachCamera()
         {
             if (attachedCamera == null)
@@ -80,6 +82,8 @@ namespace Trajectories
 
         private void setDisplayEnabled(bool enabled)
         {
+            groundTraceObj.GetComponent<MeshRenderer>().enabled = Settings.fetch.GroundTraceMode;
+
             enabled = enabled && Settings.fetch.DisplayTrajectories;
 
             if (displayEnabled == enabled)
@@ -134,7 +138,7 @@ namespace Trajectories
                 GameObject.Destroy(mesh);
             }
         }
-
+        
         private void refreshMesh()
         {
             foreach (var mesh in meshes)
@@ -169,12 +173,16 @@ namespace Trajectories
                 {
                     initMeshFromOrbit(patch.startingState.referenceBody.position, mesh, patch.spaceOrbit, patch.startingState.time, patch.endTime - patch.startingState.time, Color.white);
 
-                    var groundTraceObj = GetMesh(patch.startingState.referenceBody, lineMaterial);
+                    groundTraceObj = GetMesh(patch.startingState.referenceBody, lineMaterial);
                     var groundTraceMesh = groundTraceObj.GetComponent<MeshFilter>().mesh;
 
                     if (Settings.fetch.GroundTraceMode)
                     {
                         initMeshFromOrbit(patch.startingState.referenceBody.position, groundTraceMesh, patch.spaceOrbit, patch.startingState.time, patch.endTime - patch.startingState.time, XKCDColors.Orange, true);
+
+                    } else
+                    {
+                        
                     }
                 }
 

--- a/Plugin/MapOverlay.cs
+++ b/Plugin/MapOverlay.cs
@@ -168,14 +168,6 @@ namespace Trajectories
                 else
                 {
                     initMeshFromOrbit(patch.startingState.referenceBody.position, mesh, patch.spaceOrbit, patch.startingState.time, patch.endTime - patch.startingState.time, Color.white);
-
-                    var groundTraceObj = GetMesh(patch.startingState.referenceBody, lineMaterial);
-                    var groundTraceMesh = groundTraceObj.GetComponent<MeshFilter>().mesh;
-
-                    if (Settings.fetch.GroundTraceMode)
-                    {
-                        initMeshFromOrbit(patch.startingState.referenceBody.position, groundTraceMesh, patch.spaceOrbit, patch.startingState.time, patch.endTime - patch.startingState.time, XKCDColors.Orange, true);
-                    }
                 }
 
                 if (patch.impactPosition.HasValue)
@@ -234,7 +226,7 @@ namespace Trajectories
             }
         }
 
-        private void initMeshFromOrbit(Vector3 bodyPosition, Mesh mesh, Orbit orbit, double startTime, double duration, Color color, bool groundTrace = false)
+        private void initMeshFromOrbit(Vector3 bodyPosition, Mesh mesh, Orbit orbit, double startTime, double duration, Color color)
         {
             int steps = 128;
 
@@ -246,7 +238,7 @@ namespace Trajectories
             double maxDT = Math.Max(1.0, duration / (double)steps);
             double maxDTA = 2.0 * Math.PI / (double)steps;
             stepUT[utIdx++] = startTime;
-            while (true)
+            while(true)
             {
                 double time = prevTime + maxDT;
                 for (int count = 0; count < 100; ++count)
@@ -264,7 +256,7 @@ namespace Trajectories
                     time = (prevTime + time) * 0.5;
                 }
 
-                if (time > startTime + duration - (time - prevTime) * 0.5)
+                if (time > startTime + duration - (time-prevTime) * 0.5)
                     break;
 
                 prevTime = time;
@@ -283,7 +275,7 @@ namespace Trajectories
             var triangles = new int[utIdx * 6];
 
             Vector3 prevMeshPos = Util.SwapYZ(orbit.getRelativePositionAtUT(startTime - duration / (double)steps)) + bodyPosition;
-            for (int i = 0; i < utIdx; ++i)
+            for(int i = 0; i < utIdx; ++i)
             {
                 double time = stepUT[i];
 
@@ -292,7 +284,7 @@ namespace Trajectories
                     curMeshPos = Trajectory.calculateRotatedPosition(orbit.referenceBody, curMeshPos, time);
                 }
 
-                if (groundTrace)
+                if (Settings.fetch.GroundTraceMode)
                 {
                     curMeshPos = Trajectory.projectToSurface(orbit.referenceBody, curMeshPos, time);
                 }
@@ -323,7 +315,7 @@ namespace Trajectories
             for (int i = 0; i < colors.Length; ++i)
             {
                 //if (color.g < 0.5)
-                colors[i] = color;
+                    colors[i] = color;
                 /*else
                     colors[i] = new Color(0, (float)i / (float)colors.Length, 1.0f - (float)i / (float)colors.Length);*/
             }

--- a/Plugin/MapOverlay.cs
+++ b/Plugin/MapOverlay.cs
@@ -182,10 +182,6 @@ namespace Trajectories
                     if (Settings.fetch.GroundTraceMode)
                     {
                         initMeshFromOrbit(patch.startingState.referenceBody.position, groundTraceMesh, patch.spaceOrbit, patch.startingState.time, patch.endTime - patch.startingState.time, XKCDColors.Orange, true);
-
-                    } else
-                    {
-                        
                     }
                 }
 

--- a/Plugin/MapOverlay.cs
+++ b/Plugin/MapOverlay.cs
@@ -295,7 +295,7 @@ namespace Trajectories
                 double time = stepUT[i];
 
                 Vector3 curMeshPos = Util.SwapYZ(orbit.getRelativePositionAtUT(time));
-                if (Settings.fetch.BodyFixedMode) {
+                if (Settings.fetch.BodyFixedMode || groundTrace) {
                     curMeshPos = Trajectory.calculateRotatedPosition(orbit.referenceBody, curMeshPos, time);
                 }
 

--- a/Plugin/MapOverlay.cs
+++ b/Plugin/MapOverlay.cs
@@ -159,7 +159,7 @@ namespace Trajectories
 
             foreach (var patch in Trajectory.fetch.patches)
             {
-                if (patch.startingState.stockPatch != null && !Settings.fetch.GroundTraceMode && !Settings.fetch.BodyFixedMode && !Settings.fetch.DisplayCompleteTrajectory)
+                if (patch.startingState.stockPatch != null && !Settings.fetch.BodyFixedMode && !Settings.fetch.DisplayCompleteTrajectory)
                     continue;
 
                 if (patch.isAtmospheric && patch.atmosphericTrajectory.Length < 2)

--- a/Plugin/MapOverlay.cs
+++ b/Plugin/MapOverlay.cs
@@ -156,20 +156,10 @@ namespace Trajectories
                 lineMaterial = MapView.fetch.orbitLinesMaterial;
             }
 
-            if (Settings.fetch.GroundTraceMode)
-            {
-                foreach (var patch in Trajectory.fetch.patches)
-                {
-                    groundTraceObj = GetMesh(patch.startingState.referenceBody, lineMaterial);
-                    var groundTraceMesh = groundTraceObj.GetComponent<MeshFilter>().mesh;
-
-                    initMeshFromOrbit(patch.startingState.referenceBody.position, groundTraceMesh, patch.spaceOrbit, patch.startingState.time, patch.endTime - patch.startingState.time, XKCDColors.Orange, true);
-                }
-            }
 
             foreach (var patch in Trajectory.fetch.patches)
             {
-                if (patch.startingState.stockPatch != null && !Settings.fetch.BodyFixedMode && !Settings.fetch.DisplayCompleteTrajectory)
+                if (patch.startingState.stockPatch != null && !Settings.fetch.GroundTraceMode && !Settings.fetch.BodyFixedMode && !Settings.fetch.DisplayCompleteTrajectory)
                     continue;
 
                 if (patch.isAtmospheric && patch.atmosphericTrajectory.Length < 2)
@@ -185,6 +175,14 @@ namespace Trajectories
                 else
                 {
                     initMeshFromOrbit(patch.startingState.referenceBody.position, mesh, patch.spaceOrbit, patch.startingState.time, patch.endTime - patch.startingState.time, Color.white);
+
+                    groundTraceObj = GetMesh(patch.startingState.referenceBody, lineMaterial);
+                    var groundTraceMesh = groundTraceObj.GetComponent<MeshFilter>().mesh;
+
+                    if (Settings.fetch.GroundTraceMode)
+                    {
+                        initMeshFromOrbit(patch.startingState.referenceBody.position, groundTraceMesh, patch.spaceOrbit, patch.startingState.time, patch.endTime - patch.startingState.time, XKCDColors.Orange, true);
+                    }
                 }
 
                 if (patch.impactPosition.HasValue)

--- a/Plugin/MapOverlay.cs
+++ b/Plugin/MapOverlay.cs
@@ -168,6 +168,14 @@ namespace Trajectories
                 else
                 {
                     initMeshFromOrbit(patch.startingState.referenceBody.position, mesh, patch.spaceOrbit, patch.startingState.time, patch.endTime - patch.startingState.time, Color.white);
+
+                    var groundTraceObj = GetMesh(patch.startingState.referenceBody, lineMaterial);
+                    var groundTraceMesh = groundTraceObj.GetComponent<MeshFilter>().mesh;
+
+                    if (Settings.fetch.GroundTraceMode)
+                    {
+                        initMeshFromOrbit(patch.startingState.referenceBody.position, groundTraceMesh, patch.spaceOrbit, patch.startingState.time, patch.endTime - patch.startingState.time, XKCDColors.Orange, true);
+                    }
                 }
 
                 if (patch.impactPosition.HasValue)
@@ -226,7 +234,7 @@ namespace Trajectories
             }
         }
 
-        private void initMeshFromOrbit(Vector3 bodyPosition, Mesh mesh, Orbit orbit, double startTime, double duration, Color color)
+        private void initMeshFromOrbit(Vector3 bodyPosition, Mesh mesh, Orbit orbit, double startTime, double duration, Color color, bool groundTrace = false)
         {
             int steps = 128;
 
@@ -238,7 +246,7 @@ namespace Trajectories
             double maxDT = Math.Max(1.0, duration / (double)steps);
             double maxDTA = 2.0 * Math.PI / (double)steps;
             stepUT[utIdx++] = startTime;
-            while(true)
+            while (true)
             {
                 double time = prevTime + maxDT;
                 for (int count = 0; count < 100; ++count)
@@ -256,7 +264,7 @@ namespace Trajectories
                     time = (prevTime + time) * 0.5;
                 }
 
-                if (time > startTime + duration - (time-prevTime) * 0.5)
+                if (time > startTime + duration - (time - prevTime) * 0.5)
                     break;
 
                 prevTime = time;
@@ -275,7 +283,7 @@ namespace Trajectories
             var triangles = new int[utIdx * 6];
 
             Vector3 prevMeshPos = Util.SwapYZ(orbit.getRelativePositionAtUT(startTime - duration / (double)steps)) + bodyPosition;
-            for(int i = 0; i < utIdx; ++i)
+            for (int i = 0; i < utIdx; ++i)
             {
                 double time = stepUT[i];
 
@@ -284,7 +292,7 @@ namespace Trajectories
                     curMeshPos = Trajectory.calculateRotatedPosition(orbit.referenceBody, curMeshPos, time);
                 }
 
-                if (Settings.fetch.GroundTraceMode)
+                if (groundTrace)
                 {
                     curMeshPos = Trajectory.projectToSurface(orbit.referenceBody, curMeshPos, time);
                 }
@@ -315,7 +323,7 @@ namespace Trajectories
             for (int i = 0; i < colors.Length; ++i)
             {
                 //if (color.g < 0.5)
-                    colors[i] = color;
+                colors[i] = color;
                 /*else
                     colors[i] = new Color(0, (float)i / (float)colors.Length, 1.0f - (float)i / (float)colors.Length);*/
             }

--- a/Plugin/MapOverlay.cs
+++ b/Plugin/MapOverlay.cs
@@ -82,9 +82,12 @@ namespace Trajectories
 
         private void setDisplayEnabled(bool enabled)
         {
-            groundTraceObj.GetComponent<MeshRenderer>().enabled = Settings.fetch.GroundTraceMode;
-
             enabled = enabled && Settings.fetch.DisplayTrajectories;
+
+            if (groundTraceObj)
+            {
+                groundTraceObj.GetComponent<MeshRenderer>().enabled = enabled && Settings.fetch.GroundTraceMode;
+            }
 
             if (displayEnabled == enabled)
                 return;

--- a/Plugin/MapOverlay.cs
+++ b/Plugin/MapOverlay.cs
@@ -156,10 +156,20 @@ namespace Trajectories
                 lineMaterial = MapView.fetch.orbitLinesMaterial;
             }
 
+            if (Settings.fetch.GroundTraceMode)
+            {
+                foreach (var patch in Trajectory.fetch.patches)
+                {
+                    groundTraceObj = GetMesh(patch.startingState.referenceBody, lineMaterial);
+                    var groundTraceMesh = groundTraceObj.GetComponent<MeshFilter>().mesh;
+
+                    initMeshFromOrbit(patch.startingState.referenceBody.position, groundTraceMesh, patch.spaceOrbit, patch.startingState.time, patch.endTime - patch.startingState.time, XKCDColors.Orange, true);
+                }
+            }
 
             foreach (var patch in Trajectory.fetch.patches)
             {
-                if (patch.startingState.stockPatch != null && !Settings.fetch.GroundTraceMode && !Settings.fetch.BodyFixedMode && !Settings.fetch.DisplayCompleteTrajectory)
+                if (patch.startingState.stockPatch != null && !Settings.fetch.BodyFixedMode && !Settings.fetch.DisplayCompleteTrajectory)
                     continue;
 
                 if (patch.isAtmospheric && patch.atmosphericTrajectory.Length < 2)
@@ -175,14 +185,6 @@ namespace Trajectories
                 else
                 {
                     initMeshFromOrbit(patch.startingState.referenceBody.position, mesh, patch.spaceOrbit, patch.startingState.time, patch.endTime - patch.startingState.time, Color.white);
-
-                    groundTraceObj = GetMesh(patch.startingState.referenceBody, lineMaterial);
-                    var groundTraceMesh = groundTraceObj.GetComponent<MeshFilter>().mesh;
-
-                    if (Settings.fetch.GroundTraceMode)
-                    {
-                        initMeshFromOrbit(patch.startingState.referenceBody.position, groundTraceMesh, patch.spaceOrbit, patch.startingState.time, patch.endTime - patch.startingState.time, XKCDColors.Orange, true);
-                    }
                 }
 
                 if (patch.impactPosition.HasValue)

--- a/Plugin/MapOverlay.cs
+++ b/Plugin/MapOverlay.cs
@@ -295,7 +295,7 @@ namespace Trajectories
                 double time = stepUT[i];
 
                 Vector3 curMeshPos = Util.SwapYZ(orbit.getRelativePositionAtUT(time));
-                if (Settings.fetch.BodyFixedMode || groundTrace) {
+                if (Settings.fetch.BodyFixedMode) {
                     curMeshPos = Trajectory.calculateRotatedPosition(orbit.referenceBody, curMeshPos, time);
                 }
 

--- a/Plugin/MapOverlay.cs
+++ b/Plugin/MapOverlay.cs
@@ -167,7 +167,14 @@ namespace Trajectories
                 }
                 else
                 {
-                    initMeshFromOrbit(patch.startingState.referenceBody.position, mesh, patch.spaceOrbit, patch.startingState.time, patch.endTime - patch.startingState.time, Color.white);
+                    if (Settings.fetch.GroundTraceMode)
+                    {
+                        initMeshFromOrbit(patch.startingState.referenceBody.position, mesh, patch.spaceOrbit, patch.startingState.time, patch.endTime - patch.startingState.time, XKCDColors.Orange);
+                    }
+                    else
+                    {
+                        initMeshFromOrbit(patch.startingState.referenceBody.position, mesh, patch.spaceOrbit, patch.startingState.time, patch.endTime - patch.startingState.time, Color.white);
+                    }
                 }
 
                 if (patch.impactPosition.HasValue)

--- a/Plugin/MapOverlay.cs
+++ b/Plugin/MapOverlay.cs
@@ -156,16 +156,19 @@ namespace Trajectories
                 lineMaterial = MapView.fetch.orbitLinesMaterial;
             }
 
-            foreach (var patch in Trajectory.fetch.patches)
+            if (Settings.fetch.GroundTraceMode)
             {
-                if (Settings.fetch.GroundTraceMode)
+                foreach (var patch in Trajectory.fetch.patches)
                 {
                     groundTraceObj = GetMesh(patch.startingState.referenceBody, lineMaterial);
                     var groundTraceMesh = groundTraceObj.GetComponent<MeshFilter>().mesh;
 
                     initMeshFromOrbit(patch.startingState.referenceBody.position, groundTraceMesh, patch.spaceOrbit, patch.startingState.time, patch.endTime - patch.startingState.time, XKCDColors.Orange, true);
                 }
+            }
 
+            foreach (var patch in Trajectory.fetch.patches)
+            {
                 if (patch.startingState.stockPatch != null && !Settings.fetch.BodyFixedMode && !Settings.fetch.DisplayCompleteTrajectory)
                     continue;
 

--- a/Plugin/Settings.cs
+++ b/Plugin/Settings.cs
@@ -41,6 +41,9 @@ namespace Trajectories
         [Persistent(Default: false)]
         public bool BodyFixedMode { get; set; }
 
+        [Persistent(Default: false)]
+        public bool GroundTraceMode { get; set; }
+
         [Persistent(Default: true)]
         public bool AutoUpdateAerodynamicModel { get; set; }
 

--- a/Plugin/Trajectory.cs
+++ b/Plugin/Trajectory.cs
@@ -268,13 +268,14 @@ namespace Trajectories
 
         public static Vector3 projectToSurface(CelestialBody body, Vector3 curMeshPos, double time)
         {
+            float offset = 10000.0f;
             var bodyPosition = body.position;
             var curMeshPosWorld = curMeshPos + bodyPosition;
             var orbit = body.orbit;
             var latitude = body.GetLatitude(curMeshPosWorld);
             var longitude = body.GetLongitude(curMeshPosWorld);
             var NormalV = body.GetSurfaceNVector(latitude, longitude);
-            var ScaledNormalVec = (NormalV * (float)body.GetAltitude(curMeshPosWorld));
+            var ScaledNormalVec = NormalV * ( (float)body.GetAltitude(curMeshPosWorld) - offset) ;
             var projectedMeshPos = curMeshPos - ScaledNormalVec;
             return projectedMeshPos;
         }

--- a/Plugin/Trajectory.cs
+++ b/Plugin/Trajectory.cs
@@ -266,6 +266,19 @@ namespace Trajectories
             }
         }
 
+        public static Vector3 projectToSurface(CelestialBody body, Vector3 curMeshPos, double time)
+        {
+            var bodyPosition = body.position;
+            var curMeshPosWorld = curMeshPos + bodyPosition;
+            var orbit = body.orbit;
+            var latitude = body.GetLatitude(curMeshPosWorld);
+            var longitude = body.GetLongitude(curMeshPosWorld);
+            var NormalV = body.GetSurfaceNVector(latitude, longitude);
+            var ScaledNormalVec = (NormalV * (float)body.GetAltitude(curMeshPosWorld));
+            var projectedMeshPos = curMeshPos - ScaledNormalVec;
+            return projectedMeshPos;
+        }
+
         private IEnumerable<bool> computeTrajectoryIncrement(Vessel vessel, DescentProfile profile)
         {
             if (aerodynamicModel_ == null || !aerodynamicModel_.isValidFor(vessel, vessel.mainBody))


### PR DESCRIPTION
This PR adds ground trace options in order to figure out where on the surface the vessel will be on.
This is useful for temperature scan missions above certain altitude where we can simply set the orbit such that the orbit crosses the given target.

Picture below demonstrates use case

PS: I really have trouble editing the file due to my unfamiliarity with UTF with BOM. As such, the diffs of the files includes everything, not just the changes that I made. I would be more than happy to help, if only I know how.

![image](https://user-images.githubusercontent.com/1199566/27325639-49768ab2-55d3-11e7-865f-b6835f6f8422.png)
Image 1: Normal mode

![image](https://user-images.githubusercontent.com/1199566/27325646-4ed92a1e-55d3-11e7-9d8f-631f56cb18c1.png)
Image 2: Dropping ground trace to surface by clicking "Ground Trace mode"

![image](https://user-images.githubusercontent.com/1199566/27325651-51f93ea0-55d3-11e7-92cd-60c4fb587c95.png)
Image 3: maneuver node adjusts inclination change to cross target  

![image](https://user-images.githubusercontent.com/1199566/27325655-5468e2f8-55d3-11e7-906c-a2a060a82ff2.png)
Image 4: And done!
