### PR TITLE
Integrate telemetry module

### DIFF
--- a/Plugin/Trajectories.csproj
+++ b/Plugin/Trajectories.csproj
@@ -86,6 +86,7 @@
     <Compile Include="FlightOverlay.cs" />
     <Compile Include="Utilities\DebugFastStart.cs" />
     <Compile Include="Utilities\Profiler.cs" />
+    <Compile Include="Utilities\TelemetryWrapper.cs" />
     <Compile Include="Utilities\TrajectoriesDebug.cs" />
     <Compile Include="DescentProfile.cs" />
     <Compile Include="MapGUI.cs" />

--- a/Plugin/Utilities/TelemetryWrapper.cs
+++ b/Plugin/Utilities/TelemetryWrapper.cs
@@ -1,0 +1,71 @@
+﻿#if DEBUG_TELEMETRY
+
+using System;
+using System.Reflection;
+using UnityEngine;
+
+namespace Trajectories
+{
+    public class Telemetry
+    {
+        private static string thisAssemblyName = Assembly.GetExecutingAssembly().GetName().Name;
+
+        private static object telemetryServiceInstance = null;
+        private static MethodInfo addChannelMethod;
+        private static MethodInfo sendMethod;
+
+
+        public static void AddChannel<ChannelType>(string id, string format = null)
+            where ChannelType : IFormattable
+        {
+            if (telemetryServiceInstance == null)
+                return;
+
+            // AddChannel is generic, we find the concrete implementation
+            MethodInfo addChannelMethodConcrete =
+                addChannelMethod.MakeGenericMethod(typeof(ChannelType));
+
+            var parameters = new object[] { thisAssemblyName + "/" + id, format };
+            addChannelMethodConcrete.Invoke(telemetryServiceInstance, parameters);
+        }
+
+        public static void Send(string id, object value)
+        {
+            if (telemetryServiceInstance == null)
+                return;
+
+            var parameters = new object[] { thisAssemblyName + "/" + id, value };
+            sendMethod.Invoke(telemetryServiceInstance, parameters);
+        }
+
+
+        static Telemetry()
+        {
+            // Search for telemetry assembly
+            Type telemetryServiceType = null;
+            foreach (var loadedAssembly in AssemblyLoader.loadedAssemblies)
+            {
+                if (loadedAssembly.name != "Telemetry")
+                    continue;
+
+                telemetryServiceType = loadedAssembly.assembly.GetType("Telemetry.TelemetryService");
+            }
+
+            // if it's not loaded, bow and excuse ourselves
+            if (telemetryServiceType == null)
+            {
+                Debug.Log(thisAssemblyName + " could not find Telemetry module. Continuing without Telemetry.");
+                return;
+            }
+
+            // if it's loaded, get instance and Send/AddChannel Methods
+            telemetryServiceInstance = telemetryServiceType.GetProperty("Instance", telemetryServiceType).GetValue(null, null);
+            addChannelMethod = telemetryServiceType.GetMethod("AddChannel");
+            sendMethod = telemetryServiceType.GetMethod("Send");
+
+            Debug.Log(thisAssemblyName + " connected to Telemetry module.");
+        }
+    }
+}
+
+#endif


### PR DESCRIPTION
Writing numerical values to the screen allows only for a very limited analysis of numerical errors.

We can use the newly created [Telemetry Plugin](https://github.com/fat-lobyte/KSPTelemetry) that takes values and writes them to a Tab Separated File.
These data files can than be read by other data analysis tools such as MATLAB and Jupyter to perform more intricate error analysis.

This Pull Request does not introduce any hard dependencies. Rather, the wrapper code inside Trajectories binds to the Telemetry Plugin during runtime  - but only if it's present.
If the Telemetry Plugin is not present, the API methods in the Wrapper turn into no-op's with almost no overhead.