### PR TITLE
Changed Profiler to use KSP's PopupDialog class

### DIFF
--- a/Plugin/MapGUI.cs
+++ b/Plugin/MapGUI.cs
@@ -68,7 +68,7 @@ namespace Trajectories
 
         public void OnGUI()
         {
-            if (!Settings.fetch.GUIEnabled || !Util.IsFlight() || PlanetariumCamera.Camera == null)
+            if (!Settings.fetch.GUIEnabled || !Util.IsFlight || PlanetariumCamera.Camera == null)
                 return;
 
             Settings.fetch.MapGUIWindowPos = new Rect(Settings.fetch.MapGUIWindowPos.xMin, Settings.fetch.MapGUIWindowPos.yMin, Settings.fetch.MapGUIWindowPos.width, Settings.fetch.MapGUIWindowPos.height - 1);

--- a/Plugin/Util.cs
+++ b/Plugin/Util.cs
@@ -33,7 +33,7 @@ namespace Trajectories
                     throw new Exception("method not found");
                 return res;
             }
-            catch(Exception e)
+            catch (Exception e)
             {
                 throw new Exception("Failed to GetMethod " + methodName + " on type " + type.FullName + " with flags " + flags + ":\n" + e.Message + "\n" + e.StackTrace);
             }
@@ -91,110 +91,131 @@ namespace Trajectories
 
 
 
-    // --------------------------------------------------------------------------
-    // --- TIME -----------------------------------------------------------------
+        // --------------------------------------------------------------------------
+        // --- TIME -----------------------------------------------------------------
 
-    // return hours in a day
-    public static double HoursInDay()
-    {
-      return GameSettings.KERBIN_TIME ? 6.0 : 24.0;
-    }
+        /// <summary> Return hours in a KSP day. </summary>
+        public static double HoursInDay
+        {
+            get
+            {
+                return GameSettings.KERBIN_TIME ? 6.0 : 24.0;
+            }
+        }
 
-    // return year length
-    public static double DaysInYear()
-    {
-      if (!FlightGlobals.ready)
-        return 426.0;
-      return Math.Floor(FlightGlobals.GetHomeBody().orbit.period / (HoursInDay() * 60.0 * 60.0));
-    }
+        /// <summary> Return days in a KSP year. </summary>
+        public static double DaysInYear
+        {
+            get
+            {
+                if (!FlightGlobals.ready)
+                    return 426.0;
+                return Math.Floor(FlightGlobals.GetHomeBody().orbit.period / (HoursInDay * 60.0 * 60.0));
+            }
+        }
 
-    // get current time
-    public static UInt64 Clocks()
-    {
-      return (UInt64)Stopwatch.GetTimestamp();
-    }
+        /// <summary> Get current time in clocks. </summary>
+        public static double Clocks
+        {
+            get
+            {
+                return Stopwatch.GetTimestamp();
+            }
+        }
 
-    // convert from clocks to microseconds
-    public static double Microseconds(UInt64 clocks)
-    {
-      return (double)clocks * 1000000.0 / (double)Stopwatch.Frequency;
-    }
+        /// <summary> Convert from clocks to microseconds. </summary>
+        public static double Microseconds(double clocks)
+        {
+            return clocks * 1000000.0 / Stopwatch.Frequency;
+        }
 
+        /// <summary> Convert from clocks to milliseconds. </summary>
+        public static double Milliseconds(double clocks)
+        {
+            return clocks * 1000.0 / Stopwatch.Frequency;
+        }
 
-    public static double Milliseconds(UInt64 clocks)
-    {
-      return (double)clocks * 1000.0 / (double)Stopwatch.Frequency;
-    }
-
-
-    public static double Seconds(UInt64 clocks)
-    {
-      return (double)clocks / (double)Stopwatch.Frequency;
-    }
-
-
-
-    // --------------------------------------------------------------------------
-    // --- GAME LOGIC -----------------------------------------------------------
-
-    // return true if the current scene is flight
-    public static bool IsFlight()
-    {
-      return HighLogic.LoadedSceneIsFlight;
-    }
-
-    // return true if the current scene is editor
-    public static bool IsEditor()
-    {
-      return HighLogic.LoadedSceneIsEditor;
-    }
-
-    // return true if the current scene is not the main menu
-    public static bool IsGame()
-    {
-      return HighLogic.LoadedSceneIsGame;
-    }
-
-    // return true if game is paused
-    public static bool IsPaused()
-    {
-      return FlightDriver.Pause || Planetarium.Pause;
-    }
+        /// <summary> Convert from clocks to seconds. </summary>
+        public static double Seconds(double clocks)
+        {
+            return clocks / Stopwatch.Frequency;
+        }
 
 
 
-    // --------------------------------------------------------------------------
-    // --- RANDOM ---------------------------------------------------------------
+        // --------------------------------------------------------------------------
+        // --- GAME LOGIC -----------------------------------------------------------
 
-    // store the random number generator
-    static System.Random rng = new System.Random();
+        /// <summary> Returns true if the current scene is flight. </summary>
+        public static bool IsFlight
+        {
+            get
+            {
+                return HighLogic.LoadedSceneIsFlight;
+            }
+        }
 
-    // return random integer
-    public static int RandomInt(int max_value)
-    {
-      return rng.Next(max_value);
-    }
+        /// <summary> Returns true if the current scene is editor. </summary>
+        public static bool IsEditor
+        {
+            get
+            {
+                return HighLogic.LoadedSceneIsEditor;
+            }
+        }
 
-    // return random float [0..1]
-    public static float RandomFloat()
-    {
-      return (float)rng.NextDouble();
-    }
+        /// <summary> Returns true if the current scene is not the main menu. </summary>
+        public static bool IsGame
+        {
+            get
+            {
+                return HighLogic.LoadedSceneIsGame;
+            }
+        }
 
-    // return random double [0..1]
-    public static double RandomDouble()
-    {
-      return rng.NextDouble();
-    }
+        /// <summary> Returns true if game is paused. </summary>
+        public static bool IsPaused
+        {
+            get
+            {
+                return FlightDriver.Pause || Planetarium.Pause;
+            }
+        }
 
-    // return random float in [-1,+1] range
-    // note: it is less random than the c# RNG, but is way faster
-    static int fast_float_seed = 1;
-    public static float FastRandomFloat()
-    {
-      fast_float_seed *= 16807;
-      return (float)fast_float_seed * 4.6566129e-010f;
-    }
+
+
+        // --------------------------------------------------------------------------
+        // --- RANDOM ---------------------------------------------------------------
+
+        /// <summary> Random number generator. </summary>
+        static System.Random rng = new System.Random();
+
+        /// <summary> Returns random integer in [0..max_value] range. </summary>
+        public static int RandomInt(int max_value)
+        {
+            return rng.Next(max_value);
+        }
+
+        /// <summary> Returns random float in [0..1] range. </summary>
+        public static float RandomFloat()
+        {
+            return (float)rng.NextDouble();
+        }
+
+        /// <summary> Returns random double in [0..1] range. </summary>
+        public static double RandomDouble()
+        {
+            return rng.NextDouble();
+        }
+
+        static int fast_float_seed = 1;
+        /// <summary> Returns random float in [-1,+1] range.
+        /// Note: it is less random than the c# RNG, but is way faster. </summary>
+        public static float FastRandomFloat()
+        {
+            fast_float_seed *= 16807;
+            return (float)fast_float_seed * 4.6566129e-010f;
+        }
 
 
 

--- a/Plugin/Utilities/Profiler.cs
+++ b/Plugin/Utilities/Profiler.cs
@@ -2,237 +2,214 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
+using KSP.Localization;
 using UnityEngine;
 
 
 namespace Trajectories
 {
-
-
-  [KSPAddon(KSPAddon.Startup.MainMenu, true)]
-  public sealed class Profiler: MonoBehaviour
-  {
-    // constants
-    const float width = 400.0f;
-    const float height = 500.0f;
-    const float top_height = 20.0f;
-    const float bot_height = 20.0f;
-    const float margin = 10.0f;
-    const float spacing = 10.0f;
-
-    // permit global access
-    private static Profiler instance = null;
-
-    // styles
-    GUIStyle win_style;
-    GUIStyle top_style;
-    GUIStyle name_style;
-    GUIStyle value_style;
-
-    // store window id
-    int win_id;
-
-    // store window geometry
-    Rect win_rect;
-
-    // store dragbox geometry
-    Rect drag_rect;
-
-    // used by scroll window mechanics
-    Vector2 scroll_pos;
-
-    // visible flag
-    bool visible;
-
-    // an entry in the profiler
-    class entry
+    /// <summary> Simple profiler for measuring the execution time of code placed between the Start and Stop methods. </summary>
+    [KSPAddon(KSPAddon.Startup.MainMenu, true)]
+    public sealed class Profiler: MonoBehaviour
     {
-      public UInt64 start;        // used to measure call time
-      public UInt64 calls;        // number of calls in current simulation step
-      public UInt64 time;         // time in current simulation step
-      public UInt64 prev_calls;   // number of calls in previous simulation step
-      public UInt64 prev_time;    // time in previous simulation step
-      public UInt64 tot_calls;    // number of calls in total
-      public UInt64 tot_time;     // total time
+        // constants
+        private const float width = 400.0f;
+        private const float height = 500.0f;
 
-    }
+        private const float value_width = 65.0f;
 
-    // store all entries
-    Dictionary<string, entry> entries = new Dictionary<string, entry>();
+        // permit global access
+        private static Profiler instance = null;
 
+        // visible flag
+        private static bool visible;
 
-    // ctor
-    Profiler()
-    {
-      // enable global access
-      instance = this;
+        // popup window 
+        private static MultiOptionDialog multi_dialog;
+        private static PopupDialog popup_dialog;
+        private static DialogGUIVerticalLayout dialog_items;
 
-      // generate unique id, hopefully
-      win_id = Util.RandomInt(int.MaxValue);
+        // an entry in the profiler
+        private class entry
+        {
+            public double start;        // used to measure call time
+            public double calls;        // number of calls in current simulation step
+            public double time;         // time in current simulation step
+            public double prev_calls;   // number of calls in previous simulation step
+            public double prev_time;    // time in previous simulation step
+            public double tot_calls;    // number of calls in total
+            public double tot_time;     // total time
+        }
 
-      // setup window geometry
-      win_rect = new Rect((Screen.width - width) * 0.5f, (Screen.height - height) * 0.5f, width, height);
-
-      // setup dragbox geometry
-      drag_rect = new Rect(0.0f, 0.0f, width, top_height);
-
-      // setup styles
-      win_style = new GUIStyle(HighLogic.Skin.window);
-      top_style = new GUIStyle();
-      name_style = new GUIStyle();
-      value_style = new GUIStyle();
-    }
-
-    //  Awake is called only once when the script instance is being loaded. Used in place of the constructor for initialization.
-    public void Awake()
-    {
-      // keep it alive
-      DontDestroyOnLoad(this);
-
-      // setup styles
-      win_style.padding.top = 0;
-      win_style.padding.bottom = 0;
-      top_style.fixedHeight = top_height;
-      top_style.fontStyle = FontStyle.Bold;
-      top_style.alignment = TextAnchor.MiddleCenter;
-      name_style.fontSize = 10;
-      name_style.fixedWidth = 150.0f;
-      name_style.stretchWidth = false;
-      value_style.fontSize = 10;
-      value_style.fixedWidth = 75.0f;
-      value_style.stretchWidth = false;
-      value_style.alignment = TextAnchor.MiddleRight;
-    }
-
-    // called every frame
-    public void OnGUI()
-    {
-      if (Util.IsGame() && visible)
-      {
-        // clamp the window to the screen, so it can't be dragged outside
-        float offset_x = Math.Max(0.0f, -win_rect.xMin) + Math.Min(0.0f, Screen.width - win_rect.xMax);
-        float offset_y = Math.Max(0.0f, -win_rect.yMin) + Math.Min(0.0f, Screen.height - win_rect.yMax);
-        win_rect.xMin += offset_x;
-        win_rect.xMax += offset_x;
-        win_rect.yMin += offset_y;
-        win_rect.yMax += offset_y;
-
-        // draw the window
-        win_rect = GUILayout.Window(win_id, win_rect, render, "", win_style);
-      }
-    }
+        // store all entries
+        private Dictionary<string, entry> entries = new Dictionary<string, entry>();
 
 
-    // draw the window
-    void render(int id)
-    {
-      // draw pseudo-title
-      GUILayout.BeginHorizontal();
-      GUILayout.Label("Profiler", top_style);
-      GUILayout.EndHorizontal();
+        public static Profiler Instance
+        {
+            get
+            {
+                return instance;
+            }
+        }
 
-      // draw top spacing
-      GUILayout.Space(spacing);
+        //  constructor
+        public Profiler()
+        {
+            // enable global access
+            instance = this;
 
-      // draw entries
-      scroll_pos = GUILayout.BeginScrollView(scroll_pos, HighLogic.Skin.horizontalScrollbar, HighLogic.Skin.verticalScrollbar);
-      GUILayout.BeginHorizontal();
-      GUILayout.Label("<b>NAME</b>", name_style);
-      GUILayout.Label("<b>LAST</b>", value_style);
-      GUILayout.Label("<b>AVG</b>", value_style);
-      GUILayout.Label("<b>CALLS</b>", value_style);
-      GUILayout.EndHorizontal();
-      foreach (var pair in entries)
-      {
-        string e_name = pair.Key;
-        entry e = pair.Value;
-        GUILayout.BeginHorizontal();
-        GUILayout.Label(e_name, name_style);
-        GUILayout.Label(e.prev_calls > 0 ? Util.Microseconds(e.prev_time / e.prev_calls).ToString("F2") : "", value_style);
-        GUILayout.Label(e.tot_calls > 0 ? Util.Microseconds(e.tot_time / e.tot_calls).ToString("F2") : "", value_style);
-        GUILayout.Label(e.prev_calls.ToString(), value_style);
-        GUILayout.EndHorizontal();
-      }
-      GUILayout.EndScrollView();
+            // create window
+            dialog_items = new DialogGUIVerticalLayout();
+            multi_dialog = new MultiOptionDialog(
+               "TrajectoriesProfilerWindow",
+               "",
+               GetTitle(),
+               HighLogic.UISkin,
+               new Rect(0.5f, 0.5f, width, height),
+               new DialogGUIBase[]
+               {
+                   // create header line
+                   new DialogGUIHorizontalLayout(
+                       new DialogGUILabel("<b>   NAME</b>", true),
+                       new DialogGUILabel("<b>LAST</b>", value_width),
+                       new DialogGUILabel("<b>AVG</b>", value_width),
+                       new DialogGUILabel("<b>CALLS</b>", value_width - 15)),
+                   // create scrollbox for entry data
+                   new DialogGUIScrollList(new Vector2(), false, true, dialog_items)
+               });
+        }
 
-      // draw bottom spacing
-      GUILayout.Space(spacing);
+        // Awake is called only once when the script instance is being loaded. Used in place of the constructor for initialization.
+        private void Awake()
+        {
+            // keep it alive
+            DontDestroyOnLoad(this);
 
-      // enable dragging
-      GUI.DragWindow(drag_rect);
-    }
+            // create popup dialog
+            popup_dialog = PopupDialog.SpawnPopupDialog(multi_dialog, true, HighLogic.UISkin, false, "");
+            if (popup_dialog != null)
+                popup_dialog.gameObject.SetActive(false);
+        }
 
+        private void Update()
+        {
+            if ((Input.GetKey(KeyCode.LeftControl) || Input.GetKey(KeyCode.RightControl)) &&
+                     Input.GetKeyUp(KeyCode.P) && popup_dialog != null)
+            {
+                visible = !visible;
+                popup_dialog.gameObject.SetActive(visible);
+            }
+        }
 
-    public void Update()
-    {
-      if ((Input.GetKey(KeyCode.LeftControl) || Input.GetKey(KeyCode.RightControl)) && Input.GetKeyUp(KeyCode.P))
-      {
-        visible = !visible;
-      }
-    }
+        private void FixedUpdate()
+        {
+            foreach (var p in entries)
+            {
+                entry e = p.Value;
+                e.prev_calls = e.calls;
+                e.prev_time = e.time;
+                e.tot_calls += e.calls;
+                e.tot_time += e.time;
+                e.calls = 0;
+                e.time = 0;
+            }
+        }
 
+        private void OnDestroy()
+        {
+            instance = null;
+            popup_dialog.Dismiss();
+            popup_dialog = null;
+        }
 
-    public void FixedUpdate()
-    {
-      foreach (var p in entries)
-      {
-        entry e = p.Value;
-        e.prev_calls = e.calls;
-        e.prev_time = e.time;
-        e.tot_calls += e.calls;
-        e.tot_time += e.time;
-        e.calls = 0;
-        e.time = 0;
-      }
-    }
+        private static string GetTitle()
+        {
+            switch (Localizer.CurrentLanguage)
+            {
+                case "es-es":
+                    return "Trayectorias Profiler";
+                case "ru":
+                    return "Провайдер траектории";
+                case "zh-cn":
+                    return "軌跡分析儀";
+                default:
+                    return "Trajectories Profiler";
+            }
+        }
 
+        private void AddDialogItem(string e_name)
+        {
+            // add item
+            dialog_items.AddChild(
+                new DialogGUIHorizontalLayout(
+                    new DialogGUILabel("  " + e_name, true),
+                    new DialogGUILabel(() =>
+                    {
+                        return (entries[e_name].prev_calls > 0 ? Util.Microseconds(entries[e_name].prev_time /
+                                    entries[e_name].prev_calls).ToString("F2") : "") + "ms";
+                    }, value_width),
+                    new DialogGUILabel(() =>
+                    {
+                        return (entries[e_name].tot_calls > 0 ? Util.Microseconds(entries[e_name].tot_time /
+                                    entries[e_name].tot_calls).ToString("F2") : "") + "ms";
+                    }, value_width),
+                    new DialogGUILabel(() =>
+                    {
+                        return entries[e_name].prev_calls.ToString();
+                    }, value_width - 15)));
 
-    // start an entry
-    public static void Start(string e_name)
-    {
-      if (instance == null)
-        return;
+            // required to force the Gui creation
+            Stack<Transform> stack = new Stack<Transform>();
+            stack.Push(dialog_items.uiItem.gameObject.transform);
+            dialog_items.children[dialog_items.children.Count - 1].Create(ref stack, HighLogic.UISkin);
+        }
 
-      if (!instance.entries.ContainsKey(e_name))
-        instance.entries.Add(e_name, new entry());
+        /// <summary> Start a profiler entry. </summary>
+        public static void Start(string e_name)
+        {
+            if (instance == null)
+                return;
 
-      entry e = instance.entries[e_name];
-      e.start = Util.Clocks();
+            if (!instance.entries.ContainsKey(e_name))
+            {
+                instance.entries.Add(e_name, new entry());
+                instance.AddDialogItem(e_name);
+            }
+
+            instance.entries[e_name].start = Util.Clocks;
+        }
+
+        /// <summary> Stop a profiler entry. </summary>
+        public static void Stop(string e_name)
+        {
+            if (instance == null)
+                return;
+
+            entry e = instance.entries[e_name];
+
+            ++e.calls;
+            e.time += Util.Clocks - e.start;
+        }
     }
 
 
-    // stop an entry
-    public static void Stop(string e_name)
+    /// <summary> Profile a function scope. </summary>
+    public class ProfileScope: IDisposable
     {
-      if (instance == null)
-        return;
+        public ProfileScope(string name)
+        {
+            this.name = name;
+            Profiler.Start(name);
+        }
 
-      entry e = instance.entries[e_name];
+        public void Dispose()
+        {
+            Profiler.Stop(name);
+        }
 
-      ++e.calls;
-      e.time += Util.Clocks() - e.start;
+        private string name;
     }
-  }
-
-
-  // profile a function scope
-  public class ProfileScope: IDisposable
-  {
-    public ProfileScope(string name)
-    {
-      this.name = name;
-      Profiler.Start(name);
-    }
-
-    public void Dispose()
-    {
-      Profiler.Stop(name);
-    }
-
-
-    private string name;
-  }
 
 
 } // Trajectories


### PR DESCRIPTION
The Profiler GUI has been updated to use KSP's PopupDialog class which in turn uses a GameObject with a canvas and also has the added benefit of stopping most mouse click through events, even to the context menus :)

One drawback though is I cant stop clicks getting through to the manoeuvre nodes on the map view >.<

Also changed some comments to summaries and added {get; } to some methods in the Utils.cs file.

I'm thinking using KSP's Dialog class could be a way for the main Trajectories window to be displayed, as it seems to have the functionality we need.
