### PR TITLE
BugFix for Issue #102 - Crash when turning on In-Flight trajectory display while in Map view

### DIFF
--- a/Plugin/FlightOverlay.cs
+++ b/Plugin/FlightOverlay.cs
@@ -1,10 +1,9 @@
 ﻿using UnityEngine;
-using Vectrosity;
 
 namespace Trajectories
 {
     [KSPAddon(KSPAddon.Startup.Flight, false)]
-    public class FlightOverlay : MonoBehaviour
+    public class FlightOverlay: MonoBehaviour
     {
         private const int defaultVertexCount = 32;
         private const float lineWidth = 2.0f;
@@ -20,24 +19,24 @@ namespace Trajectories
 
         public void Start()
         {
-			line = gameObject.AddComponent<LineRenderer>();
+            line = gameObject.AddComponent<LineRenderer>();
             line.useWorldSpace = false; // true;
-			line.SetVertexCount(defaultVertexCount);
+            line.SetVertexCount(defaultVertexCount);
             line.SetWidth(lineWidth, lineWidth);
-			line.sharedMaterial = Resources.Load("DefaultLine3D") as Material;
-			line.material.SetColor("_TintColor", new Color(0.1f, 1f, 0.1f));
+            line.sharedMaterial = Resources.Load("DefaultLine3D") as Material;
+            line.material.SetColor("_TintColor", new Color(0.1f, 1f, 0.1f));
         }
 
         private void FixedUpdate()
         {
+            line.enabled = false;
+            targetingCross.enabled = false;
+
             if (!Settings.fetch.DisplayTrajectories
+                || Util.IsMap
                 || !Settings.fetch.DisplayTrajectoriesInFlight
                 || Trajectory.fetch.patches.Count == 0)
-            {
-                line.enabled = false;
-                targetingCross.enabled = false;
                 return;
-            }
 
             Vector3[] vertices;
 
@@ -57,7 +56,7 @@ namespace Trajectories
                 vertices = new Vector3[defaultVertexCount];
 
                 double time = lastPatch.startingState.time;
-                double time_increment = (lastPatch.endTime - lastPatch.startingState.time) / (float) defaultVertexCount;
+                double time_increment = (lastPatch.endTime - lastPatch.startingState.time) / defaultVertexCount;
                 Orbit orbit = lastPatch.spaceOrbit;
                 for (uint i = 0; i < defaultVertexCount; ++i)
                 {
@@ -100,7 +99,7 @@ namespace Trajectories
         }
     }
 
-    public class TargetingCross : MonoBehaviour
+    public class TargetingCross: MonoBehaviour
     {
         public const float impactRaycastDistance = 300.0f;
 

--- a/Plugin/MapGUI.cs
+++ b/Plugin/MapGUI.cs
@@ -5,11 +5,14 @@ using UnityEngine;
 
 namespace Trajectories
 {
-    class GUIToggleButtonBlizzyVisibility : IVisibility
+    class GUIToggleButtonBlizzyVisibility: IVisibility
     {
         internal static GUIToggleButtonBlizzyVisibility Instance
         {
-            get { return new GUIToggleButtonBlizzyVisibility(); }
+            get
+            {
+                return new GUIToggleButtonBlizzyVisibility();
+            }
         }
 
         private static IVisibility FLIGHT_VISIBILITY;
@@ -30,7 +33,7 @@ namespace Trajectories
     }
 
     [KSPAddon(KSPAddon.Startup.Flight, false)]
-    class MapGUI : MonoBehaviour
+    class MapGUI: MonoBehaviour
     {
         private static readonly int GUIId = 934824;
 
@@ -162,12 +165,18 @@ namespace Trajectories
                     && lastPatchBody == targetBody && traj.targetPosition.HasValue)
                 {
                     // Get Latitude and Longitude from impact position
+                    double impactLat;
+                    double impatLon;
+                    double impactAlt;
                     impactPos = lastPatch.impactPosition.Value + lastPatchBody.position;
-                    lastPatchBody.GetLatLonAlt(impactPos, out double impactLat, out double impatLon, out double impactAlt);
+                    lastPatchBody.GetLatLonAlt(impactPos, out impactLat, out impatLon, out impactAlt);
 
                     // Get Latitude and Longitude for target position
+                    double targetLat;
+                    double targetLon;
+                    double targetAlt;
                     targetPos = traj.targetPosition.Value + targetBody.position;
-                    targetBody.GetLatLonAlt(targetPos, out double targetLat, out double targetLon, out double targetAlt);
+                    targetBody.GetLatLonAlt(targetPos, out targetLat, out targetLon, out targetAlt);
 
                     float targetDistance = (float)(Util.distanceFromLatitudeAndLongitude(targetBody.Radius + impactAlt,
                         impactLat, impatLon, targetLat, targetLon) / 1e3);
@@ -303,7 +312,9 @@ namespace Trajectories
                     var body = FlightGlobals.currentMainBody;
                     if (latLng.Length == 2 && body != null)
                     {
-                        if (Double.TryParse(latLng[0].Trim(), out double lat) && Double.TryParse(latLng[1].Trim(), out double lng))
+                        double lat;
+                        double lng;
+                        if (double.TryParse(latLng[0].Trim(), out lat) && double.TryParse(latLng[1].Trim(), out lng))
                         {
                             Vector3d relPos = body.GetWorldSurfacePosition(lat, lng, 2.0) - body.position;
                             double altitude = Trajectory.GetGroundAltitude(body, relPos) + body.Radius;
@@ -435,7 +446,7 @@ namespace Trajectories
                     ApplicationLauncher.AppScenes.MAPVIEW | ApplicationLauncher.AppScenes.FLIGHT,
                     (Texture)GameDatabase.Instance.GetTexture("Trajectories/Textures/icon", false));
 
-                if(Settings.fetch.GUIEnabled)
+                if (Settings.fetch.GUIEnabled)
                     GUIToggleButton.SetTrue(false);
             }
         }

--- a/Plugin/Util.cs
+++ b/Plugin/Util.cs
@@ -173,6 +173,24 @@ namespace Trajectories
             }
         }
 
+        /// <summary> Returns true if the current scene is tracking station. </summary>
+        public static bool IsTrackingStation
+        {
+            get
+            {
+                return (HighLogic.LoadedScene == GameScenes.TRACKSTATION);
+            }
+        }
+
+        /// <summary> Returns true if the current view is map. </summary>
+        public static bool IsMap
+        {
+            get
+            {
+                return MapView.MapIsEnabled;
+            }
+        }
+
         /// <summary> Returns true if game is paused. </summary>
         public static bool IsPaused
         {


### PR DESCRIPTION
Used a work around for [Issue #102](https://github.com/neuoy/KSPTrajectories/issues/102) suggested by @fat-lobyte.
 Fix works by simply setting `line.enabled` to false and checking we are not in map view before changing any vertices and setting `line.enabled` to true.

Also fixed some syntax in MapGUI.cs