### PR TITLE
Return 0 aero force from FAR if vessel is packed

### DIFF
--- a/Plugin/AerodynamicModel/FARModel.cs
+++ b/Plugin/AerodynamicModel/FARModel.cs
@@ -19,6 +19,7 @@ namespace Trajectories
         protected override Vector3d ComputeForces_Model(Vector3d airVelocity, double altitude)
         {
             //Debug.Log("Trajectories: getting FAR forces");
+            if (vessel_.packed) { return Vector3.zero; }
             Vector3 worldAirVel = new Vector3((float)airVelocity.x, (float)airVelocity.y, (float)airVelocity.z);
             var parameters = new object[] { vessel_, new Vector3(), new Vector3(), worldAirVel, altitude };
             FARAPI_CalculateVesselAeroForces.Invoke(null, parameters);


### PR DESCRIPTION
FAR assumes vessels are unpacked when calculating aero forces. Trying to calculate aero forces with a packed vessel leads to NREs:

```
[EXC 23:01:17.989] NullReferenceException: Object reference not set to an instance of an object
	FerramAerospaceResearch.FARAeroComponents.FARVesselAero.SimulateAeroProperties (UnityEngine.Vector3& aeroForce, UnityEngine.Vector3& aeroTorque, Vector3 velocityWorldVector, Double altitude)
	FerramAerospaceResearch.FARAPI.InstanceCalcVesselAeroForces (.Vessel vessel, UnityEngine.Vector3& aeroForce, UnityEngine.Vector3& aeroTorque, Vector3 velocityWorldVector, Double altitude)
	FerramAerospaceResearch.FARAPI.CalculateVesselAeroForces (.Vessel vessel, UnityEngine.Vector3& aeroForce, UnityEngine.Vector3& aeroTorque, Vector3 velocityWorldVector, Double altitude)
	System.Reflection.MonoMethod.Invoke (System.Object obj, BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture)
	Rethrow as TargetInvocationException: Exception has been thrown by the target of an invocation.
	System.Reflection.MonoMethod.Invoke (System.Object obj, BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture)
	System.Reflection.MethodBase.Invoke (System.Object obj, System.Object[] parameters)
	Trajectories.FARModel.ComputeForces_Model (Vector3d airVelocity, Double altitude)
	Trajectories.VesselAerodynamicModel.ComputeForces (Double altitude, Vector3d airVelocity, Vector3d vup, Double angleOfAttack)
	Trajectories.VesselAerodynamicModel.ComputeReferenceDrag ()
	Trajectories.VesselAerodynamicModel.isValidFor (.Vessel vessel, .CelestialBody body)
	Trajectories.Trajectory+<computeTrajectoryIncrement>d__47.MoveNext ()
	Trajectories.Trajectory.ComputeTrajectory (.Vessel vessel, Trajectories.DescentProfile profile)
```

Problem found by/fix proposed by lamont in MJ code.