### PR TITLE
Better precision and Performance with Runge-Kutta-4 integrator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
  * ModuleManager updated to v3.0.0
  * When combined with FAR, aerodynamic forces calculated on a packed vessel would lead to NRE's. Vessels are now
     no longer calculated when a vessel is in a packed state. Thanks go to Alex Wang for this bug fix.
+ * Higher precision and better performance through more advanced numeric techniques.
+   Try disabling the Cache for more precise predictions predictions that should not kill your FPS anymore.
 
 ### For Developers
 

--- a/Plugin/AerodynamicModel/VesselAerodynamicModel.cs
+++ b/Plugin/AerodynamicModel/VesselAerodynamicModel.cs
@@ -162,6 +162,7 @@ namespace Trajectories
         /// <returns>The computed aerodynamic forces in world space</returns>
         public Vector3d ComputeForces(double altitude, Vector3d airVelocity, Vector3d vup, double angleOfAttack)
         {
+            Profiler.Start("ComputeForces");
             if (!vessel_.mainBody.atmosphere)
                 return Vector3d.zero;
             if (altitude >= body_.atmosphereDepth)
@@ -221,6 +222,9 @@ namespace Trajectories
                 Debug.Log("Trajectories: res is NaN (altitude=" + altitude + ", airVelocity=" + airVelocity.magnitude + ", angleOfAttack=" + angleOfAttack);
                 return new Vector3d(0, 0, 0); // Don't send NaN into the simulation as it would cause bad things (infinite loops, crash, etc.). I think this case only happens at the atmosphere edge, so the total force should be 0 anyway.
             }
+
+
+            Profiler.Stop("ComputeForces");
             return res;
         }
 

--- a/Plugin/Properties/AssemblyInfo.cs
+++ b/Plugin/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.7.1.0")]
-[assembly: AssemblyFileVersion("1.7.1.0")]
+[assembly: AssemblyVersion("1.7.1.1")]
+[assembly: AssemblyFileVersion("1.7.1.1")]

--- a/Plugin/Settings.cs
+++ b/Plugin/Settings.cs
@@ -50,6 +50,9 @@ namespace Trajectories
         [Persistent(Default: false)]
         public bool GUIEnabled { get; set; }
 
+        [Persistent(Default: 2.0f)]
+        public float IntegrationStepSize { get; set; } 
+
         [Persistent(Default: 4)]
         public int MaxPatchCount { get; set; }
 

--- a/Plugin/Trajectory.cs
+++ b/Plugin/Trajectory.cs
@@ -667,7 +667,7 @@ namespace Trajectories
                     patch.startingState.stockPatch = null;
 
                     // lower dt would be more accurate, but a tradeoff has to be found between performances and accuracy
-                    double dt = 0.1;
+                    double dt = 1.0;
 
                     // some shallow entries can result in very long flight. For performances reasons,
                     // we limit the prediction duration
@@ -800,9 +800,8 @@ namespace Trajectories
                         Profiler.Start("VerletStep");
 
                         // Verlet integration (more precise than using the velocity)
-                        state = VerletStep(state, accelerationFunc, dt);
-
-                        // state = RK4Step(state, accelerationFunc, dt);
+                        // state = VerletStep(state, accelerationFunc, dt);
+                        state = RK4Step(state, accelerationFunc, dt);
 
 
 

--- a/Plugin/Trajectory.cs
+++ b/Plugin/Trajectory.cs
@@ -667,7 +667,7 @@ namespace Trajectories
                     patch.startingState.stockPatch = null;
 
                     // lower dt would be more accurate, but a tradeoff has to be found between performances and accuracy
-                    double dt = 2.0;
+                    double dt = Settings.fetch.IntegrationStepSize;
 
                     // some shallow entries can result in very long flight. For performances reasons,
                     // we limit the prediction duration


### PR DESCRIPTION
Up until now, Trajectories used the Verlet integration scheme. This worked kind of alright, however it required a rather small step size, which lead to rather hefty performance penalty.
To alleviate this, the force cache was introduced that sped up the force calculation, but came with its own drawback of decreased precision.

Using a more advanced integration Scheme like the Runga-Kutta 4 Integration allows a much higher integration step (improving performance) while maintaining precision.

There are now 4 invocations of the force function instead of one, but this allowed us to increase the stepsize from 0.1s to 2.0s, resulting in a `2.0 / 0.1 / 4 = 5`-fold performance increase, while maintaining about the same (cache-less) precision.
This allows users to disable the cache for no or a small perfomance loss for a high increase in precision.

The step size is now variable and can be changed in the code as `Trajectories.Settings.IntegrationStepSize` or in the settings by adding `<float name="IntegrationStepSize">2.0</float>` to `/GameData/Trajectories/Plugin/PluginData/Trajectories/config.xml`. 


What I think should be done *before* merging this PR:

 * Testing! Please download and test in various situations.
 * Determining the actual performance cost compared to the Verlet (old, in master) integrator. From my testing, using the RK4 without Cache is about 1.5x slower than using Verlet *with* Cache.

What I think should be done *after* merging this PR:

 * Add a slider for the IntegrationStepSize in the Settings UI
 * Add settings and switching Code to chose the old (Verlet) or the RK-4 integrator, and the option to add more integrators
 * In the near future, I would like to try a little optimization pass. Additionally, I would like to try and limit the refresh rate of the trajectory calculation.
   We really need the result at most 0.5 times a second, unless you're doing KOS things.
 * I would like to try implement an Adaptive method like Dormand-Prince 4/5 that adapts the step size to the highest value when changes are little, and to a lower value if there are many changes. This could increase the performance even further which will allow us to completely ditch the cache.

A compiled version of this branch can be found here:

https://github.com/fat-lobyte/KSPTrajectories/releases/download/v1.7.2-pre_integrator1/Trajectories.dll