### PR TITLE
API: Added checks to help stop NRE's

### DIFF
--- a/Plugin/API.cs
+++ b/Plugin/API.cs
@@ -3,10 +3,12 @@ using UnityEngine;
 
 namespace Trajectories
 {
-    //This class only returns correct values for the "active vessel."
+    /// <summary>
+    /// This class only returns correct values for the "active vessel".
+    /// </summary>
     public static class API
     {
-        public static bool alwaysUpdate
+        public static bool AlwaysUpdate
         {
             get
             {
@@ -18,80 +20,105 @@ namespace Trajectories
             }
         }
 
-        public static double? getEndTime()
+        public static double? GetEndTime()
         {
-            foreach (var patch in Trajectory.fetch.Patches)
+            if (FlightGlobals.ActiveVessel != null)
             {
-                if (patch.ImpactPosition.HasValue)
-                    return patch.EndTime;
-            }
-            return null;
-        }
-
-        public static Vector3? getImpactPosition()
-        {
-            foreach (var patch in Trajectory.fetch.Patches)
-            {
-                if (patch.ImpactPosition != null)
-                    return patch.ImpactPosition;
-            }
-            return null;
-        }
-
-        public static Vector3? getImpactVelocity()
-        {
-            foreach (var patch in Trajectory.fetch.Patches)
-            {
-                if (patch.ImpactVelocity != null)
-                    return patch.ImpactVelocity;
-            }
-            return null;
-        }
-
-        public static Orbit getSpaceOrbit()
-        {
-            foreach (var patch in Trajectory.fetch.Patches)
-            {
-                if (patch.StartingState.StockPatch != null)
+                foreach (var patch in Trajectory.fetch.Patches)
                 {
-                    continue;
-                }
-
-                if (patch.IsAtmospheric)
-                {
-                    continue;
-                }
-
-                if (patch.SpaceOrbit != null)
-                {
-                    return patch.SpaceOrbit;
+                    if (patch.ImpactPosition.HasValue)
+                        return patch.EndTime;
                 }
             }
-
             return null;
         }
 
-        public static Vector3 plannedDirection()
+        public static Vector3? GetImpactPosition()
         {
-            return NavBallOverlay.GetPlannedDirection();
-        }
-
-        public static Vector3 correctedDirection()
-        {
-            return NavBallOverlay.GetCorrectedDirection();
-        }
-
-        public static void setTarget(double lat,double lon,double alt = 2.0)
-        {
-            var body = FlightGlobals.Bodies.SingleOrDefault(b => b.isHomeWorld);
-            if (body != null)
+            if (FlightGlobals.ActiveVessel != null)
             {
-                Vector3d worldPos = body.GetWorldSurfacePosition(lat, lon, alt);
-                Trajectory.Target.Set(body, worldPos - body.position);
+                foreach (var patch in Trajectory.fetch.Patches)
+                {
+                    if (patch.ImpactPosition != null)
+                        return patch.ImpactPosition;
+                }
+            }
+            return null;
+        }
+
+        public static Vector3? GetImpactVelocity()
+        {
+            if (FlightGlobals.ActiveVessel != null)
+            {
+                foreach (var patch in Trajectory.fetch.Patches)
+                {
+                    if (patch.ImpactVelocity != null)
+                        return patch.ImpactVelocity;
+                }
+            }
+            return null;
+        }
+
+        public static Orbit GetSpaceOrbit()
+        {
+            foreach (var patch in Trajectory.fetch.Patches)
+            {
+                if (FlightGlobals.ActiveVessel != null)
+                {
+                    if (patch.StartingState.StockPatch != null)
+                    {
+                        continue;
+                    }
+
+                    if (patch.IsAtmospheric)
+                    {
+                        continue;
+                    }
+
+                    if (patch.SpaceOrbit != null)
+                    {
+                        return patch.SpaceOrbit;
+                    }
+                }
+            }
+            return null;
+        }
+
+        public static Vector3? PlannedDirection()
+        {
+            if (FlightGlobals.ActiveVessel != null && Trajectory.Target.Body != null)
+                return NavBallOverlay.GetPlannedDirection();
+            return null;
+        }
+
+        public static Vector3? CorrectedDirection()
+        {
+            if (FlightGlobals.ActiveVessel != null && Trajectory.Target.Body != null)
+                return NavBallOverlay.GetCorrectedDirection();
+            return null;
+        }
+
+        public static bool HasTarget()
+        {
+            if (FlightGlobals.ActiveVessel != null && Trajectory.Target.Body != null)
+                return true;
+            return false;
+        }
+
+        public static void SetTarget(double lat,double lon,double alt = 2.0)
+        {
+            if (FlightGlobals.ActiveVessel != null)
+            {
+                var body = FlightGlobals.Bodies.SingleOrDefault(b => b.isHomeWorld);    // needs fixing, vessel is not allways at kerbin
+                if (body != null)
+                {
+                    Vector3d worldPos = body.GetWorldSurfacePosition(lat, lon, alt);
+                    Trajectory.Target.Set(body, worldPos - body.position);
+                }
             }
         }
 
-        private static void updateTrajectory()
+        private static void UpdateTrajectory()
         {
             Trajectory.fetch.ComputeTrajectory(FlightGlobals.ActiveVessel, DescentProfile.fetch);
         }

--- a/Plugin/NavBallOverlay.cs
+++ b/Plugin/NavBallOverlay.cs
@@ -123,7 +123,7 @@ namespace Trajectories
         {
             var vessel = FlightGlobals.ActiveVessel;
 
-            if (vessel == null)
+            if (vessel == null || Trajectory.Target.Body == null)
                 return new Vector3(0, 0, 0);
 
             CelestialBody body = vessel.mainBody;


### PR DESCRIPTION
Added checks to API methods to stop NRE's occurring when methods are called with no active vessel.
Added `HasTarget` method that returns true when a target has been set.
Also fixed method name convention violations.

Needless to say that any mods referencing the API will need to update.
I have left a post on the kOS GitHub. Re: #124